### PR TITLE
feat: Support `max`  breakpoint

### DIFF
--- a/packages/preset-mini/src/_variants/breakpoints.ts
+++ b/packages/preset-mini/src/_variants/breakpoints.ts
@@ -35,7 +35,7 @@ export function variantBreakpoints(): VariantObject {
         if (m === 'container')
           continue
 
-        const isLtPrefix = pre.startsWith('lt-') || pre.startsWith('<')
+        const isLtPrefix = pre.startsWith('lt-') || pre.startsWith('<') || pre.startsWith('max')
         const isAtPrefix = pre.startsWith('at-') || pre.startsWith('~')
 
         let order = 1000 // parseInt(size)
@@ -77,6 +77,6 @@ export function variantBreakpoints(): VariantObject {
       }
     },
     multiPass: true,
-    autocomplete: '(at-|lt-|)$breakpoints:',
+    autocomplete: '(at-|lt-|max-|)$breakpoints:',
   }
 }

--- a/packages/preset-mini/src/_variants/breakpoints.ts
+++ b/packages/preset-mini/src/_variants/breakpoints.ts
@@ -35,7 +35,7 @@ export function variantBreakpoints(): VariantObject {
         if (m === 'container')
           continue
 
-        const isLtPrefix = pre.startsWith('lt-') || pre.startsWith('<') || pre.startsWith('max')
+        const isLtPrefix = pre.startsWith('lt-') || pre.startsWith('<') || pre.startsWith('max-')
         const isAtPrefix = pre.startsWith('at-') || pre.startsWith('~')
 
         let order = 1000 // parseInt(size)


### PR DESCRIPTION
TailwindCSS uses `max` instead of `lt` so it would be nice if we also support that. It helps users coming from TailwindCSS too.

https://tailwindcss.com/docs/responsive-design#targeting-a-breakpoint-range